### PR TITLE
LBAC-7 Added fix to select the session locaion in the location selector

### DIFF
--- a/omod/src/main/java/org/openmrs/module/locationbasedaccess/fragment/controller/field/LocationsFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/locationbasedaccess/fragment/controller/field/LocationsFragmentController.java
@@ -5,6 +5,7 @@ import org.openmrs.Location;
 import org.openmrs.Patient;
 import org.openmrs.PersonAttribute;
 import org.openmrs.PersonAttributeType;
+import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.locationbasedaccess.LocationBasedAccessConstants;
 import org.openmrs.ui.framework.fragment.FragmentModel;
 import org.openmrs.api.context.Context;
@@ -22,6 +23,11 @@ public class LocationsFragmentController {
         model.addAttribute("activeLocations", activeLocations);
 
         model.addAttribute("selectedLocationUuid", null);
+        Object sessionLocationId = session.getAttribute(UiSessionContext.LOCATION_SESSION_ATTRIBUTE);
+        if(sessionLocationId!=null && StringUtils.isNotBlank(sessionLocationId.toString())) {
+            Location sessionLocation = Context.getLocationService().getLocation(Integer.parseInt(sessionLocationId.toString()));
+            model.addAttribute("selectedLocationUuid", sessionLocation.getUuid());
+        }
         if (patient != null) {
             String locationAttributeUuid = Context.getAdministrationService().getGlobalProperty(LocationBasedAccessConstants.LOCATION_ATTRIBUTE_GLOBAL_PROPERTY_NAME);
             if (StringUtils.isNotBlank(locationAttributeUuid)) {

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <properties>
     	<openMRSVersion>2.0.5</openMRSVersion>
 		<uiframeworkVersion>3.9</uiframeworkVersion>
-		<appuiVersion>1.9</appuiVersion>
+		<appuiVersion>1.9.0-SNAPSHOT</appuiVersion>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
      </properties>
 
@@ -70,6 +70,12 @@
 				<groupId>org.openmrs.module</groupId>
 				<artifactId>uiframework-api</artifactId>
 				<version>${uiframeworkVersion}</version>
+				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>appui-omod</artifactId>
+				<version>${appuiVersion}</version>
 				<scope>provided</scope>
 			</dependency>
 


### PR DESCRIPTION
# Description 

Currently, the first item is selected default to the fragment location selector. This PR contains the fix to select the session location as the default location to the location selector in the fragment.

# Ticket

Ticket : https://issues.openmrs.org/browse/LBAC-7