### PR TITLE
LBAC-9 Added AOP Advice to getPatientByUuid method in the PatientService

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/PatientSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/PatientSearchAdviser.java
@@ -39,6 +39,9 @@ public class PatientSearchAdviser extends StaticMethodMatcherPointcutAdvisor imp
         else if (method.getName().equals("getPatient")) {
             return true;
         }
+        else if (method.getName().equals("getPatientByUuid")) {
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
# Description 

Added AOP Advice to getPatientByUuid() method in the PatientService to restrict by the location property.

# Ticket

Ticket : https://issues.openmrs.org/browse/LBAC-9