### PR TITLE
LBAC-10 Added exception for Daemon thread user to access the methods covered with AOP Advices

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/PatientSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/PatientSearchAdviser.java
@@ -20,6 +20,7 @@ import org.openmrs.Patient;
 import org.openmrs.PersonAttribute;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
 import org.springframework.aop.Advisor;
 import org.springframework.aop.support.StaticMethodMatcherPointcutAdvisor;
 import java.lang.reflect.Method;
@@ -52,9 +53,12 @@ public class PatientSearchAdviser extends StaticMethodMatcherPointcutAdvisor imp
 
     private class PatientSearchAdvise implements MethodInterceptor {
         public Object invoke(MethodInvocation invocation) throws Throwable {
+            Object object = invocation.proceed();
+            if (Daemon.isDaemonUser(Context.getAuthenticatedUser())) {
+                return object;
+            }
             Integer sessionLocationId = Context.getUserContext().getLocationId();
             String locationAttributeUuid = Context.getAdministrationService().getGlobalProperty(LocationBasedAccessConstants.LOCATION_ATTRIBUTE_GLOBAL_PROPERTY_NAME);
-            Object object = invocation.proceed();
             if (StringUtils.isNotBlank(locationAttributeUuid)) {
                 final PersonAttributeType personAttributeType = Context.getPersonService().getPersonAttributeTypeByUuid(locationAttributeUuid);
                 if (sessionLocationId != null) {


### PR DESCRIPTION
# Description
Added exception for Daemon thread to access the methods which are covered by AOP Advices in Location based access control. Then the daemon thread user will not have any restrictions to access the objects from different locations.

# Ticket
Ticket : https://issues.openmrs.org/browse/LBAC-10