### PR TITLE
LBAC-11 Added fix to allow system administrator to access all patients

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/PatientSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/PatientSearchAdviser.java
@@ -54,7 +54,7 @@ public class PatientSearchAdviser extends StaticMethodMatcherPointcutAdvisor imp
     private class PatientSearchAdvise implements MethodInterceptor {
         public Object invoke(MethodInvocation invocation) throws Throwable {
             Object object = invocation.proceed();
-            if (Daemon.isDaemonUser(Context.getAuthenticatedUser())) {
+            if (Daemon.isDaemonUser(Context.getAuthenticatedUser()) || Context.getAuthenticatedUser().isSuperUser()) {
                 return object;
             }
             Integer sessionLocationId = Context.getUserContext().getLocationId();
@@ -94,8 +94,7 @@ public class PatientSearchAdviser extends StaticMethodMatcherPointcutAdvisor imp
 
         private Boolean doesPatientBelongToGivenLocation(Patient patient, PersonAttributeType personAttributeType, String sessionLocationUuid) {
             PersonAttribute personAttribute = patient.getAttribute(personAttributeType);
-            return ((personAttribute == null && Context.getAuthenticatedUser().isSuperUser()) ||
-                    personAttribute != null && compare(personAttribute.getValue(), sessionLocationUuid));
+            return (personAttribute != null && compare(personAttribute.getValue(), sessionLocationUuid));
         }
 
         private Boolean compare(String value1, String value2) {


### PR DESCRIPTION
# Description 
Since the System Administrator should have access to all the data in the system, Location Based Access control module should give an exception to see all the patients. This PR contains the changes to allow the system administrator to access all patients in the system.

# Ticket 
Ticket : https://issues.openmrs.org/browse/LBAC-11
