### PR TITLE
LBAC-15 Added restrictions to the UserService methods to restrict them by the location

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/LocationUtils.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/LocationUtils.java
@@ -17,7 +17,10 @@ import org.openmrs.Location;
 import org.openmrs.Person;
 import org.openmrs.PersonAttribute;
 import org.openmrs.PersonAttributeType;
+import org.openmrs.User;
 import org.openmrs.api.context.Context;
+import java.util.Iterator;
+import java.util.List;
 
 public class LocationUtils {
 
@@ -39,6 +42,21 @@ public class LocationUtils {
     public static Boolean doesPersonBelongToGivenLocation(Person person, PersonAttributeType personAttributeType, String sessionLocationUuid) {
         PersonAttribute personAttribute = person.getAttribute(personAttributeType);
         return (personAttribute != null && compare(personAttribute.getValue(), sessionLocationUuid));
+    }
+
+    public static Boolean doesUserBelongToGivenLocation(User user, String sessionLocationUuid) {
+        String userLocationProperty = user.getUserProperty(LocationBasedAccessConstants.LOCATION_USER_PROPERTY_NAME);
+        return (userLocationProperty != null && compare(userLocationProperty, sessionLocationUuid));
+    }
+
+    public static Boolean doesUsersForPersonBelongToGivenLocation(Person person, String sessionLocationUuid) {
+        List<User> userList = Context.getUserService().getUsersByPerson(person, false);
+        for (Iterator<User> iterator = userList.iterator(); iterator.hasNext(); ) {
+            if(LocationUtils.doesUserBelongToGivenLocation(iterator.next(), sessionLocationUuid)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static Boolean compare(String value1, String value2) {

--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/PersonSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/PersonSearchAdviser.java
@@ -71,15 +71,20 @@ public class PersonSearchAdviser extends StaticMethodMatcherPointcutAdvisor impl
                     if(object instanceof List) {
                         List<Person> personList = (List<Person>) object;
                         for (Iterator<Person> iterator = personList.iterator(); iterator.hasNext(); ) {
-                            if(!LocationUtils.doesPersonBelongToGivenLocation(iterator.next(), personAttributeType, sessionLocationUuid)) {
-                                iterator.remove();
+                            Person thisPerson = iterator.next();
+                            if(!LocationUtils.doesPersonBelongToGivenLocation(thisPerson, personAttributeType, sessionLocationUuid)) {
+                                if(!LocationUtils.doesUsersForPersonBelongToGivenLocation(thisPerson, sessionLocationUuid)) {
+                                    iterator.remove();
+                                }
                             }
                         }
                         object = personList;
                     }
                     else if(object instanceof Person) {
                         if(!LocationUtils.doesPersonBelongToGivenLocation((Person)object, personAttributeType, sessionLocationUuid)) {
-                            object = null;
+                            if(!LocationUtils.doesUsersForPersonBelongToGivenLocation((Person)object, sessionLocationUuid)) {
+                                object = null;
+                            }
                         }
                     }
                 } else {

--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/UserSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/UserSearchAdviser.java
@@ -1,0 +1,104 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * <p>
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.locationbasedaccess;
+
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.User;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.support.StaticMethodMatcherPointcutAdvisor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+public class UserSearchAdviser extends StaticMethodMatcherPointcutAdvisor implements Advisor {
+
+    private static final Log log = LogFactory.getLog(UserSearchAdviser.class);
+
+    @Override
+    public boolean matches(Method method, Class targetClass) {
+        if (method.getName().equals("getUsers")) {
+            return true;
+        }
+        else if (method.getName().equals("getAllUsers")) {
+            return true;
+        }
+        else if (method.getName().equals("getUser")) {
+            return true;
+        }
+        else if (method.getName().equals("getUserByUuid")) {
+            return true;
+        }
+        else if (method.getName().equals("getUserByUsername")) {
+            return true;
+        }
+        else if (method.getName().equals("getUserByName")) {
+            return true;
+        }
+        else if (method.getName().equals("getUsersByPerson")) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Advice getAdvice() {
+        return new UserSearchAdvise();
+    }
+
+    private class UserSearchAdvise implements MethodInterceptor {
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            if (Context.getAuthenticatedUser() == null) {
+                return null;
+            }
+            Object object = invocation.proceed();
+            if (Daemon.isDaemonUser(Context.getAuthenticatedUser()) || Context.getAuthenticatedUser().isSuperUser()) {
+                return object;
+            }
+            Integer sessionLocationId = Context.getUserContext().getLocationId();
+            if (sessionLocationId != null) {
+                String sessionLocationUuid = Context.getLocationService().getLocation(sessionLocationId).getUuid();
+                if(object instanceof List) {
+                    List<User> userList = (List<User>) object;
+                    for (Iterator<User> iterator = userList.iterator(); iterator.hasNext(); ) {
+                        if(!LocationUtils.doesUserBelongToGivenLocation(iterator.next(), sessionLocationUuid)) {
+                            iterator.remove();
+                        }
+                    }
+                    object = userList;
+                }
+                else if(object instanceof User) {
+                    if(!LocationUtils.doesUserBelongToGivenLocation((User)object, sessionLocationUuid)) {
+                        object = null;
+                    }
+                }
+            }
+            else {
+                log.debug("Search User : Null Session Location in the UserContext");
+                if(object instanceof User) {
+                    // If the sessionLocationId is null, then return null for a User instance
+                    return null;
+                }
+                else {
+                    // If the sessionLocationId is null, then return a empty list
+                    return new ArrayList<User>();
+                }
+            }
+            return object;
+        }
+    }
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -60,5 +60,9 @@
 		<point>org.openmrs.api.EncounterService</point>
 		<class>org.openmrs.module.locationbasedaccess.EncounterSearchAdviser</class>
 	</advice>
+	<advice>
+		<point>org.openmrs.api.UserService</point>
+		<class>org.openmrs.module.locationbasedaccess.UserSearchAdviser</class>
+	</advice>
 </module>
 


### PR DESCRIPTION
# Description
- Added the restrictions to these following methods from the UserService class which is directly getting the User object from the DAO.    It can restrict by the locations while directly accessing the users for some other use cases.
   1. getUsers()
   2. getAllUsers()
   3. getUser()
   4. getUserByUuid()
   5. getUserByUsername()
   6. getUserByName()
   7. getUsersByPerson()

- Added a method to restrict person object of the users since we haven't assigned the person attribute for those persons belongs to the users.

# Ticket

Ticket : https://issues.openmrs.org/browse/LBAC-15
