### PR TITLE
LBAC-18 Added restrictions for Location service get methods

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/LocationSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/LocationSearchAdviser.java
@@ -1,0 +1,110 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * <p>
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.locationbasedaccess.aop;
+
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Location;
+import org.openmrs.User;
+import org.openmrs.api.context.Context;
+import org.openmrs.api.context.Daemon;
+import org.openmrs.module.locationbasedaccess.LocationBasedAccessConstants;
+import org.openmrs.module.locationbasedaccess.utils.LocationUtils;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.support.StaticMethodMatcherPointcutAdvisor;
+import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.ArrayList;
+
+public class LocationSearchAdviser extends StaticMethodMatcherPointcutAdvisor implements Advisor {
+
+    private static final Log log = LogFactory.getLog(LocationSearchAdviser.class);
+    Set<String> restrictedGetMethodNames = new HashSet<String>();
+
+    public LocationSearchAdviser() {
+        restrictedGetMethodNames.add("getDefaultLocation");
+        restrictedGetMethodNames.add("getDefaultLocationFromSting");
+        restrictedGetMethodNames.add("getLocationByUuid");
+        restrictedGetMethodNames.add("getAllLocations");
+        restrictedGetMethodNames.add("getLocations");
+        restrictedGetMethodNames.add("getLocationsByTag");
+        restrictedGetMethodNames.add("getRootLocations");
+        // TODO : How to address the restrictions for getLocation() method
+    }
+
+    @Override
+    public boolean matches(Method method, Class targetClass) {
+        if(restrictedGetMethodNames.contains(method.getName())) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public Advice getAdvice() {
+        return new LocationSearchAdvise();
+    }
+
+    private class LocationSearchAdvise implements MethodInterceptor {
+        public Object invoke(MethodInvocation invocation) throws Throwable {
+            Method method = invocation.getMethod();
+            Object object = invocation.proceed();
+            // Allow get methods without authentications
+            if(!Context.isAuthenticated() && restrictedGetMethodNames.contains(method.getName())) {
+                return object;
+            }
+            User authenticatedUser = Context.getAuthenticatedUser();
+            if (authenticatedUser != null && (Daemon.isDaemonUser(authenticatedUser) || authenticatedUser.isSuperUser())) {
+                return object;
+            }
+
+            if(restrictedGetMethodNames.contains(method.getName())) {
+                String accessibleLocationUuid = authenticatedUser.getUserProperty(LocationBasedAccessConstants.LOCATION_USER_PROPERTY_NAME);
+                if (StringUtils.isBlank(accessibleLocationUuid)) {
+                    Integer sessionLocationId = Context.getUserContext().getLocationId();
+                    accessibleLocationUuid = Context.getLocationService().getLocation(sessionLocationId).getUuid();
+                }
+
+                if (accessibleLocationUuid != null) {
+                    if(object instanceof List) {
+                        List<Location> locationList = (List<Location>) object;
+                        for (Iterator<Location> iterator = locationList.iterator(); iterator.hasNext(); ) {
+                            if(!LocationUtils.compare(accessibleLocationUuid, iterator.next().getUuid())) {
+                                iterator.remove();
+                            }
+                        }
+                        object = locationList;
+                    }
+                    else if(object instanceof Location) {
+                        if(!LocationUtils.compare(accessibleLocationUuid, ((Location)object).getUuid())) {
+                            object = null;
+                        }
+                    }
+                }
+                else {
+                    log.debug("Search Location : Null Session Location in the UserContext");
+                    if(object instanceof List) {
+                        // If the sessionLocationId is null, then return a empty list
+                        return new ArrayList<Location>();
+                    }
+                }
+            }
+            return object;
+        }
+    }
+}

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -64,5 +64,9 @@
 		<point>org.openmrs.api.UserService</point>
 		<class>org.openmrs.module.locationbasedaccess.aop.UserSearchAdviser</class>
 	</advice>
+	<advice>
+		<point>org.openmrs.api.LocationService</point>
+		<class>org.openmrs.module.locationbasedaccess.aop.LocationSearchAdviser</class>
+	</advice>
 </module>
 


### PR DESCRIPTION
# Descriptions 

OpenMRS Location Services is dealing with the location objects, and it serves the list of locations to the system. Since the user is assigned for a location, System should hide other locations from that user access. This PR contains the implementation to hide other locations for the userView. It follows,

- If not authenticated, then exclude all the get* Methods from the restrictions
- if authenticated,

   - add restrictions to getAll* methods.

   - exclude the getLocation(interger id), else it will be endless loop between the actual getLocation() caller and our module since we need this method inside our module to get the location information. So user can’t get all locations list, he can only get the accessible location(s) in the list. But the user might able to get the location information from differnt locations using the getLocation(interger id) method using the id(possible when he got the id from some where only). But he can’t make any changes.

    - add restrictions to all save, update methods by the locations (user should be authenticated)

# Ticket 

Ticekt : https://issues.openmrs.org/browse/LBAC-18
