### PR TITLE
LBAC-14 Added fix to check for the user property before session id for Person Restrictions

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/PersonSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/PersonSearchAdviser.java
@@ -66,18 +66,17 @@ public class PersonSearchAdviser extends StaticMethodMatcherPointcutAdvisor impl
             if (Daemon.isDaemonUser(authenticatedUser) || authenticatedUser.isSuperUser()) {
                 return object;
             }
-            Integer sessionLocationId = Context.getUserContext().getLocationId();
+            String accessibleLocationUuid = LocationUtils.getUserAccessibleLocationUuid(authenticatedUser);
             String locationAttributeUuid = Context.getAdministrationService().getGlobalProperty(LocationBasedAccessConstants.LOCATION_ATTRIBUTE_GLOBAL_PROPERTY_NAME);
             if (StringUtils.isNotBlank(locationAttributeUuid)) {
                 final PersonAttributeType personAttributeType = Context.getPersonService().getPersonAttributeTypeByUuid(locationAttributeUuid);
-                if (sessionLocationId != null) {
-                    String sessionLocationUuid = Context.getLocationService().getLocation(sessionLocationId).getUuid();
+                if (accessibleLocationUuid != null) {
                     if(object instanceof List) {
                         List<Person> personList = (List<Person>) object;
                         for (Iterator<Person> iterator = personList.iterator(); iterator.hasNext(); ) {
                             Person thisPerson = iterator.next();
-                            if (!LocationUtils.doesPersonBelongToGivenLocation(thisPerson, personAttributeType, sessionLocationUuid)) {
-                                if (!LocationUtils.doesUsersForPersonBelongToGivenLocation(thisPerson, sessionLocationUuid)) {
+                            if (!LocationUtils.doesPersonBelongToGivenLocation(thisPerson, personAttributeType, accessibleLocationUuid)) {
+                                if (!LocationUtils.doesUsersForPersonBelongToGivenLocation(thisPerson, accessibleLocationUuid)) {
                                     if (!thisPerson.getUuid().equals(authenticatedUser.getPerson().getUuid())) {
                                         iterator.remove();
                                     }
@@ -88,8 +87,8 @@ public class PersonSearchAdviser extends StaticMethodMatcherPointcutAdvisor impl
                     }
                     else if(object instanceof Person) {
                         Person thisPerson = (Person)object;
-                        if (!LocationUtils.doesPersonBelongToGivenLocation(thisPerson, personAttributeType, sessionLocationUuid)) {
-                            if (!LocationUtils.doesUsersForPersonBelongToGivenLocation(thisPerson, sessionLocationUuid)) {
+                        if (!LocationUtils.doesPersonBelongToGivenLocation(thisPerson, personAttributeType, accessibleLocationUuid)) {
+                            if (!LocationUtils.doesUsersForPersonBelongToGivenLocation(thisPerson, accessibleLocationUuid)) {
                                 if (!thisPerson.getUuid().equals(authenticatedUser.getPerson().getUuid())) {
                                     object = null;
                                 }


### PR DESCRIPTION
# Description

We implemented the LBAC for working tightly with the sessionLocationId. So it failed to work for the user through the REST service since that user will not have the sessionLocationId. So We need to give the priority to,

- First - Get the assigned location from user property (Need update)
- Second - Get the assigned location from session location (already implemented)

# Ticket 
Ticekt : https://issues.openmrs.org/browse/LBAC-14