### PR TITLE
LBAC-15 Added fix to check for the user property before session id for Users Restrictions

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/UserSearchAdviser.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/UserSearchAdviser.java
@@ -71,14 +71,13 @@ public class UserSearchAdviser extends StaticMethodMatcherPointcutAdvisor implem
             if (Daemon.isDaemonUser(authenticatedUser) || authenticatedUser.isSuperUser()) {
                 return object;
             }
-            Integer sessionLocationId = Context.getUserContext().getLocationId();
-            if (sessionLocationId != null) {
-                String sessionLocationUuid = Context.getLocationService().getLocation(sessionLocationId).getUuid();
+            String accessibleLocationUuid = LocationUtils.getUserAccessibleLocationUuid(authenticatedUser);
+            if (accessibleLocationUuid != null) {
                 if(object instanceof List) {
                     List<User> userList = (List<User>) object;
                     for (Iterator<User> iterator = userList.iterator(); iterator.hasNext(); ) {
                         User user = iterator.next();
-                        if (!LocationUtils.doesUserBelongToGivenLocation(user, sessionLocationUuid)) {
+                        if (!LocationUtils.doesUserBelongToGivenLocation(user, accessibleLocationUuid)) {
                             if (!authenticatedUser.getUuid().equals(user.getUuid())) {
                                 iterator.remove();
                             }
@@ -88,7 +87,7 @@ public class UserSearchAdviser extends StaticMethodMatcherPointcutAdvisor implem
                 }
                 else if(object instanceof User) {
                     User user = (User) object;
-                    if (!LocationUtils.doesUserBelongToGivenLocation(user, sessionLocationUuid)) {
+                    if (!LocationUtils.doesUserBelongToGivenLocation(user, accessibleLocationUuid)) {
                         if (!authenticatedUser.getUuid().equals(user.getUuid())) {
                             object = null;
                         }


### PR DESCRIPTION
# Description

We implemented the LBAC for working tightly with the sessionLocationId. So it failed to work for the user through the REST service since that user will not have the sessionLocationId. So We need to give the priority to,

- First - Get the assigned location from user property (Need update)
- Second - Get the assigned location from session location (already implemented)

# Ticket 
Ticekt : https://issues.openmrs.org/browse/LBAC-15