### PR TITLE
LBAC-23: Added tests for LocationSearchAdviser class

### DIFF
--- a/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/LocationSearchAdviserTest.java
+++ b/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/LocationSearchAdviserTest.java
@@ -1,0 +1,397 @@
+package org.openmrs.module.locationbasedaccess.aop;
+
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.openmrs.GlobalProperty;
+import org.openmrs.Location;
+import org.openmrs.LocationTag;
+import org.openmrs.User;
+import org.openmrs.api.LocationService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.locationbasedaccess.aop.common.AOPContextSensitiveTest;
+import org.openmrs.module.locationbasedaccess.aop.common.TestWithAOP;
+import org.openmrs.module.locationbasedaccess.aop.interceptor.LocationServiceInterceptorAdvice;
+import org.openmrs.util.OpenmrsConstants;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class LocationSearchAdviserTest extends AOPContextSensitiveTest {
+
+	private LocationService locationService;
+
+	private static final String LOCATION_TEST_DATA_XML_LOCATION = "include/LocationTestData.xml";
+
+	private static final String location1Uuid = "ef93c695-ac43-450a-93f8-4b2b4d50a3c8";
+	private static final String location2Uuid = "ef93c695-ac43-450a-93f8-4b2b4d50a3c9";
+	private static final String location3Uuid = "ef93c695-ac43-450a-93f8-4b2b4d50a3ca";
+	private static final String location4Uuid = "ef93c695-ac43-450a-93f8-4b2b4d50a3cb";
+	private static final String location5Uuid = "ef93c695-ac43-450a-93f8-4b2b4d50a3cc";
+	private static final String badLocationUuid = "badc0de1-cafe-d00d-0123-456789abcdef";
+
+	private static final String location2Name = "Test Location 2";
+	private static final String location3Name = "Test Location 3";
+
+	private static final String username1 = "username1";
+	private static final String username2 = "username2";
+	private static final String password = "userServiceTest";
+
+	private static final String searchQuery = "test location";
+	private static final String tagName = "Test Location Tag";
+
+	private Set<String> restrictedGetMethodNames = new HashSet<String>();
+	private Set<String> allLocationUuids = new HashSet<String>();
+	private Set<String> unretiredLocationUuids = new HashSet<String>();
+	private Set<String> rootLocationUuids = new HashSet<String>();
+	private Set<String> locationsWithTagUuids = new HashSet<String>();
+
+	public LocationSearchAdviserTest() {
+		restrictedGetMethodNames.add("getDefaultLocation");
+		restrictedGetMethodNames.add("getDefaultLocationFromSting");
+		restrictedGetMethodNames.add("getLocationByUuid");
+		restrictedGetMethodNames.add("getAllLocations");
+		restrictedGetMethodNames.add("getLocations");
+		restrictedGetMethodNames.add("getLocationsByTag");
+		restrictedGetMethodNames.add("getRootLocations");
+
+		allLocationUuids.add(location1Uuid);
+		unretiredLocationUuids.add(location1Uuid);
+		rootLocationUuids.add(location1Uuid);
+		locationsWithTagUuids.add(location1Uuid);
+
+		allLocationUuids.add(location2Uuid);
+		unretiredLocationUuids.add(location2Uuid);
+		rootLocationUuids.add(location2Uuid);
+
+		allLocationUuids.add(location3Uuid);
+		unretiredLocationUuids.add(location3Uuid);
+		locationsWithTagUuids.add(location3Uuid);
+
+		allLocationUuids.add(location4Uuid);
+
+		allLocationUuids.add(location5Uuid);
+		rootLocationUuids.add(location5Uuid);
+	}
+
+	@Override
+	protected void setInterceptorAndServices(TestWithAOP testCase) {
+		testCase.setInterceptor(new LocationServiceInterceptorAdvice(restrictedGetMethodNames));
+		testCase.addService(LocationService.class);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		locationService = Context.getLocationService();
+		executeDataSet(LOCATION_TEST_DATA_XML_LOCATION);
+	}
+
+	@Test
+	public void getDefaultLocation_adminShouldGetDefaultLocation() {
+		setDefaultLocationGP(location2Name);
+		authenticateAdmin();
+		assertAuthenticatedAdmin();
+
+		Location result = locationService.getDefaultLocation();
+		assertNotNull(result);
+		assertEquals(location2Uuid, result.getUuid());
+	}
+
+	@Test
+	public void getDefaultLocation_nonAdminWithLocationPropertyShouldGetOnlyAccessLocation() {
+		setDefaultLocationGP(location3Name);
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+
+		Location result = locationService.getDefaultLocation();
+		assertNotNull(result);
+		assertEquals(location3Uuid, result.getUuid());
+	}
+
+	@Test
+	public void getDefaultLocation_nonAdminWithLocationPropertyShouldNotGetDefaultLocationIfItsNotAccessLocation() {
+		setDefaultLocationGP(location2Name);
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+
+		Location result = locationService.getDefaultLocation();
+		assertNull(result);
+	}
+
+	@Test
+	public void getDefaultLocation_nonAdminWithoutLocationPropertyShouldGetOnlySessionLocation() {
+		setDefaultLocationGP(location2Name);
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(2);
+
+		Location result = locationService.getDefaultLocation();
+		assertNotNull(result);
+		assertEquals(location2Uuid, result.getUuid());
+	}
+
+	@Test
+	public void getLocationByUuid_adminShouldGetAllLocations() {
+		authenticateAdmin();
+		assertAuthenticatedAdmin();
+
+		assertGetLocationByUuidReturnsLocation(location1Uuid);
+		assertGetLocationByUuidReturnsLocation(location2Uuid);
+		assertGetLocationByUuidReturnsLocation(location3Uuid);
+		assertGetLocationByUuidReturnsLocation(location4Uuid);
+		assertGetLocationByUuidReturnsLocation(location5Uuid);
+		assertGetLocationByUuidReturnsNull(badLocationUuid);
+	}
+
+	@Test
+	public void getLocationByUuid_nonAdminWithLocationPropertyShouldGetOnlyAccessLocation() {
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+
+		assertGetLocationByUuidReturnsNull(location1Uuid);
+		assertGetLocationByUuidReturnsNull(location2Uuid);
+		assertGetLocationByUuidReturnsLocation(location3Uuid);
+		assertGetLocationByUuidReturnsNull(location4Uuid);
+		assertGetLocationByUuidReturnsNull(location5Uuid);
+		assertGetLocationByUuidReturnsNull(badLocationUuid);
+	}
+
+	@Test
+	public void getLocationByUuid_nonAdminWithoutLocationPropertyShouldGetOnlySessionLocation() {
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(2);
+
+		assertGetLocationByUuidReturnsNull(location1Uuid);
+		assertGetLocationByUuidReturnsLocation(location2Uuid);
+		assertGetLocationByUuidReturnsNull(location3Uuid);
+		assertGetLocationByUuidReturnsNull(location4Uuid);
+		assertGetLocationByUuidReturnsNull(location5Uuid);
+		assertGetLocationByUuidReturnsNull(badLocationUuid);
+	}
+
+	@Test
+	public void getAllLocations_adminShouldGetAllLocations() {
+		authenticateAdmin();
+		assertAuthenticatedAdmin();
+
+		List<String> result1 = getUuidsOfLocations(locationService.getAllLocations());
+		assertEquals(5, result1.size());
+		assertBothCollectionsAreEqual(allLocationUuids, result1);
+
+		List<String> result2 = getUuidsOfLocations(locationService.getAllLocations(false));
+		assertEquals(3, result2.size());
+		assertBothCollectionsAreEqual(unretiredLocationUuids, result2);
+	}
+
+	@Test
+	public void getAllLocations_nonAdminWithLocationPropertyShouldGetOnlyAccessLocation() {
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+
+		List<String> result = getUuidsOfLocations(locationService.getAllLocations());
+		assertEquals(1, result.size());
+		assertEquals(location3Uuid, result.get(0));
+	}
+
+	@Test
+	public void getAllLocations_nonAdminWithoutLocationPropertyShouldGetOnlySessionLocation() {
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(4);
+
+		List<String> result = getUuidsOfLocations(locationService.getAllLocations());
+		assertEquals(1, result.size());
+		assertEquals(location4Uuid, result.get(0));
+	}
+
+	@Test
+	public void getLocations_adminShouldGetAllLocations() {
+		authenticateAdmin();
+		assertAuthenticatedAdmin();
+
+		List<String> result1 = getUuidsOfLocations(locationService.getLocations(searchQuery));
+		assertEquals(3, result1.size());
+		assertBothCollectionsAreEqual(unretiredLocationUuids, result1);
+
+		List<String> result2 = getUuidsOfLocations(locationService.getLocations(searchQuery, null, null, true, null, null));
+		assertEquals(5, result2.size());
+		assertBothCollectionsAreEqual(allLocationUuids, result2);
+	}
+
+	@Test
+	public void getLocations_nonAdminWithLocationPropertyShouldGetOnlyAccessLocation() {
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+
+		List<String> result1 = getUuidsOfLocations(locationService.getLocations(searchQuery));
+		assertEquals(1, result1.size());
+		assertEquals(location3Uuid, result1.get(0));
+
+		List<String> result2 = getUuidsOfLocations(locationService.getLocations(searchQuery, null, null, true, null, null));
+		assertEquals(1, result2.size());
+		assertEquals(location3Uuid, result1.get(0));
+	}
+
+	@Test
+	public void getLocations_nonAdminWithoutLocationPropertyShouldGetOnlySessionLocation() {
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(2);
+
+		List<String> result1 = getUuidsOfLocations(locationService.getLocations(searchQuery));
+		assertEquals(1, result1.size());
+		assertEquals(location2Uuid, result1.get(0));
+
+		List<String> result2 = getUuidsOfLocations(locationService.getLocations(searchQuery, null, null, true, null, null));
+		assertEquals(1, result2.size());
+		assertEquals(location2Uuid, result1.get(0));
+	}
+
+	@Test
+	public void getLocationsByTag_adminShouldGetAllLocationsWithTag() {
+		authenticateAdmin();
+		assertAuthenticatedAdmin();
+		LocationTag tag = locationService.getLocationTagByName(tagName);
+
+		List<String> result = getUuidsOfLocations(locationService.getLocationsByTag(tag));
+		assertEquals(2, result.size());
+		assertBothCollectionsAreEqual(locationsWithTagUuids, result);
+	}
+
+	public void getLocationByTag_nonAdminWithLocationPropertyShouldGetOnlyAccessLocation() {
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+		LocationTag tag = locationService.getLocationTagByName(tagName);
+
+		List<String> result = getUuidsOfLocations(locationService.getLocationsByTag(tag));
+		assertEquals(1, result.size());
+		assertEquals(location3Uuid, result.get(0));
+	}
+
+	public void getLocationByTag_nonAdminWithoutLocationPropertyShouldGetOnlySessionLocation() {
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(1);
+		LocationTag tag = locationService.getLocationTagByName(tagName);
+
+		List<String> result = getUuidsOfLocations(locationService.getLocationsByTag(tag));
+		assertThat(result, empty());
+	}
+
+	@Test
+	public void getRootLocations_adminShouldGetAllRootLocations() {
+		authenticateAdmin();
+		assertAuthenticatedAdmin();
+
+		List<String> result = getUuidsOfLocations(locationService.getRootLocations(true));
+		assertEquals(3, result.size());
+		assertBothCollectionsAreEqual(rootLocationUuids, result);
+	}
+
+	@Test
+	public void getRootLocations_nonAdminWithLocationPropertyShouldNotGetLocationIfItsNotRootLocation() {
+		authenticateUserWithAccessLocation();
+		assertAuthenticatedNormalUser();
+
+		List<String> result = getUuidsOfLocations(locationService.getRootLocations(true));
+		assertThat(result, empty());
+	}
+
+	@Test
+	public void getRootLocations_nonAdminWithoutLocationPropertyShouldGetOnlySessionLocation() {
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(2);
+
+		List<String> result = getUuidsOfLocations(locationService.getRootLocations(true));
+		assertEquals(1, result.size());
+		assertEquals(location2Uuid, result.get(0));
+	}
+
+	@Test
+	public void getRootLocations_nonAdminWithoutLocationPropertyShouldNotGetLocationIfSessionLocationIsNotRootLocation() {
+		authenticateUserWithoutAccessLocation();
+		assertAuthenticatedNormalUser();
+		setSessionLocationID(3);
+
+		List<String> result = getUuidsOfLocations(locationService.getRootLocations(true));
+		assertThat(result, empty());
+	}
+
+	private void assertGetLocationByUuidReturnsLocation(String locationUuid) {
+		Location result = locationService.getLocationByUuid(locationUuid);
+		assertNotNull(result);
+		assertEquals(locationUuid, result.getUuid());
+	}
+
+	private void assertGetLocationByUuidReturnsNull(String locationUuid) {
+		Location result = locationService.getLocationByUuid(locationUuid);
+		assertNull(result);
+	}
+
+	private void assertAuthenticatedAdmin() {
+		assertTrue(Context.isAuthenticated());
+		User user = Context.getAuthenticatedUser();
+		assertNotNull(user);
+		assertTrue(user.isSuperUser());
+	}
+
+	private void assertAuthenticatedNormalUser() {
+		assertTrue(Context.isAuthenticated());
+		User user = Context.getAuthenticatedUser();
+		assertNotNull(user);
+		assertFalse(user.isSuperUser());
+	}
+
+	private <T> void assertBothCollectionsAreEqual(Collection<T> expected, Collection<T> actual) {
+		for (T item : expected) {
+			assertThat(actual, Matchers.hasItem(item));
+		}
+		for (T item : actual) {
+			assertThat(expected, Matchers.hasItem(item));
+		}
+	}
+
+	private void authenticateAdmin() {
+		Context.authenticate("admin", "test");
+	}
+
+	private void authenticateUserWithAccessLocation() {
+		Context.authenticate(username1, password);
+	}
+
+	private void authenticateUserWithoutAccessLocation() {
+		Context.authenticate(username2, password);
+	}
+
+	private void setDefaultLocationGP(String locationName) {
+		authenticateAdmin();
+		GlobalProperty gp = new GlobalProperty(OpenmrsConstants.GLOBAL_PROPERTY_DEFAULT_LOCATION_NAME, locationName);
+		Context.getAdministrationService().saveGlobalProperty(gp);
+		Context.logout();
+	}
+
+	private void setSessionLocationID(Integer locationID) {
+		Context.getUserContext().setLocationId(locationID);
+	}
+
+	private List<String> getUuidsOfLocations(Iterable<Location> locations) {
+		List<String> result = new ArrayList<String>();
+		for (Location location : locations) {
+			result.add(location.getUuid());
+		}
+		return result;
+	}
+}

--- a/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/AOPContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/AOPContextSensitiveTest.java
@@ -14,11 +14,16 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 public abstract class AOPContextSensitiveTest extends BaseModuleContextSensitiveTest implements TestWithAOP {
 
     private Class<?> interceptorClass;
+    private MethodInterceptor interceptor;
 
     private Map<Class<?>, Advice> servicesMap = new HashMap<Class<?>, Advice>();
 
     public void setInterceptor(Class<? extends MethodInterceptor> interceptorClass) {
         this.interceptorClass = interceptorClass;
+    }
+
+    public void setInterceptor(MethodInterceptor interceptor) {
+        this.interceptor = interceptor;
     }
 
     public void addService(Class<? extends OpenmrsService> serviceClass) {
@@ -33,8 +38,18 @@ public abstract class AOPContextSensitiveTest extends BaseModuleContextSensitive
         setInterceptorAndServices(this);
 
         for (Class<?> serviceClass : servicesMap.keySet()) {
-            Advice advice = (Advice) (new AdvicePoint(serviceClass.getCanonicalName(), Context.loadClass(interceptorClass
-                    .getCanonicalName()))).getClassInstance();
+            Advice advice;
+            if (interceptorClass != null) {
+                advice = (Advice) (new AdvicePoint(serviceClass.getCanonicalName(), Context.loadClass(interceptorClass
+                        .getCanonicalName()))).getClassInstance();
+            }
+            else if (interceptor != null) {
+                advice = interceptor;
+            }
+            else {
+                throw new IllegalStateException("You must either set interceptor or interceptor class to setup the Context");
+            }
+
             servicesMap.put(serviceClass, advice);
             Context.addAdvice(Context.loadClass(serviceClass.getCanonicalName()), advice);
         }

--- a/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/TestWithAOP.java
+++ b/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/TestWithAOP.java
@@ -13,6 +13,12 @@ public interface TestWithAOP {
     void setInterceptor(Class<? extends MethodInterceptor> interceptorClass);
 
     /**
+     * Sets an AOP method interceptor to be active on the test case.
+     *
+     * @param interceptor Eg. "MyInterceptor"
+     */
+    void setInterceptor(MethodInterceptor interceptor);
+    /**
      * Hooks the OpenMRS Services
      *
      * @param serviceClass

--- a/api/src/test/resources/include/LocationTestData.xml
+++ b/api/src/test/resources/include/LocationTestData.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+    This Source Code Form is subject to the terms of the Mozilla Public License,
+    v. 2.0. If a copy of the MPL was not distributed with this file, You can
+    obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+    the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+    Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+    graphic logo is a trademark of OpenMRS Inc.
+-->
+<dataset>
+    <person person_id="1" gender="" birthdate="1975-06-30" birthdate_estimated="false" dead="false" date_created="2005-01-01 00:00:00.0" voided="false" uuid="6adb7c42-cfd2-4301-b53b-ff17c5654ff7"/>
+    <role role="Authenticated" description="Every person logged in automatically has this role." uuid="0dc8933e-7105-4c3b-b86c-15618d854660"/>
+    <role role="System Developer" description="Administrators of the OpenMRS .. have additional access to change fundamental structure of the database model." uuid="0e43640b-67d1-4458-b47f-b64fd8ce4b0d"/>
+    <users user_id="1" person_id="1" system_id="1-8" username="admin" password="4a1750c8607d0fa237de36c6305715c223415189" salt="c788c6ad82a157b712392ca695dfcf2eed193d7f" secret_question="" creator="1" date_created="2005-01-01 00:00:00.0" changed_by="1" date_changed="2007-09-20 21:54:12.0" retired="false" retire_reason="" uuid="1010d442-e134-11de-babe-001e378eb67e"/>
+    <users user_id="0" person_id="1" system_id="daemon" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" retire_reason="" uuid="A4F30A1B-5EB9-11DF-A648-37A07F9C90FB"/>
+    <user_role user_id="1" role="System Developer"/>
+
+    <role role="userRole" description="This is a test parent role" uuid="8de52b9e-e07d-4978-ba4a-a3828c13e489"/>
+    <privilege privilege="Get Locations" description="This is a test privilege" uuid="d979d066-15e6-467c-9d4b-cb575ef97f50"/>
+    <role_privilege role="userRole" privilege="Get Locations"/>
+
+    <person person_id="6001" gender="M" dead="false" creator="1" date_created="2008-08-15 15:57:09.0" voided="false" uuid="dc99369f-f88e-4d54-be56-100e1ff45cf1"/>
+    <person_name person_name_id="6001" preferred="true" person_id="6001" given_name="User" middle_name="Without" family_name="accessLocation" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="f5bbff8e-e53b-11de-8404-001e378eb671"/>
+    <users user_id="6001" person_id="6001" system_id="6-7" username="username1" salt="3b293c5448d5e6a62a3db8734636bf185e95c9dc4d8e54d37e17073ec8046e8a566eb8046581f96a821bbe33f21d2fae28154343f0b59fedd2ed9e0d578ac6ae" password="8836e4c323e2f2df47ef5a1fcd599d8033e5daf66a414cc16faa20474df600acbecda9765fd7078b115e9f17662112eb6921e22826e8460e2a65b6e8bfd8abd4" secret_question="secret" secret_answer="cfd32f98c491f9f79803490923db520524e79fbfc885763421f8ad6440b04437405ecf5c73e7147ecd6f4d99080dd857a408218d0509305eb0fba22d7d2ad90d" creator="1" date_created="2008-08-15 15:57:09.0" changed_by="1" date_changed="2008-08-18 11:51:56.0" retired="false" retire_reason="" uuid="0bc18050-e132-11de-babe-001e378eb67f"/>
+    <user_role user_id="6001" role="userRole" />
+    <user_property user_id="6001" property="locationUuid" property_value="ef93c695-ac43-450a-93f8-4b2b4d50a3ca" />
+
+    <person person_id="6002" gender="M" dead="false" creator="1" date_created="2008-08-15 15:57:09.0" voided="false" uuid="dc59369f-f88e-4d54-be56-100e1ff45cf1"/>
+    <person_name person_name_id="6002" preferred="true" person_id="6002" given_name="User" middle_name="With" family_name="accessLocation" creator="1" date_created="2005-01-01 00:00:00.0" voided="false" uuid="f4bbff8e-e53b-11de-8404-001e378eb671"/>
+    <users user_id="6002" person_id="6002" system_id="6-8" username="username2" salt="3b293c5448d5e6a62a3db8734636bf185e95c9dc4d8e54d37e17073ec8046e8a566eb8046581f96a821bbe33f21d2fae28154343f0b59fedd2ed9e0d578ac6ae" password="8836e4c323e2f2df47ef5a1fcd599d8033e5daf66a414cc16faa20474df600acbecda9765fd7078b115e9f17662112eb6921e22826e8460e2a65b6e8bfd8abd4" secret_question="secret" secret_answer="cfd32f98c491f9f79803490923db520524e79fbfc885763421f8ad6440b04437405ecf5c73e7147ecd6f4d99080dd857a408218d0509305eb0fba22d7d2ad90d" creator="1" date_created="2008-08-15 15:57:09.0" changed_by="1" date_changed="2008-08-18 11:51:56.0" retired="false" retire_reason="" uuid="0bc28050-e132-11de-babe-001e378eb67f"/>
+    <user_role user_id="6002" role="userRole" />
+
+    <location location_id="1" name="Test Location 1" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="ef93c695-ac43-450a-93f8-4b2b4d50a3c8"/>
+    <location location_id="2" name="Test Location 2" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="ef93c695-ac43-450a-93f8-4b2b4d50a3c9"/>
+    <location location_id="3" name="Test Location 3" parent_location="1" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="ef93c695-ac43-450a-93f8-4b2b4d50a3ca"/>
+    <location location_id="4" name="Test Location 4" parent_location="1" creator="1" date_created="2005-01-01 00:00:00.0" retired="true" uuid="ef93c695-ac43-450a-93f8-4b2b4d50a3cb"/>
+    <location location_id="5" name="Test Location 5" creator="1" date_created="2005-01-01 00:00:00.0" retired="true" uuid="ef93c695-ac43-450a-93f8-4b2b4d50a3cc"/>
+
+    <location_tag location_tag_id="1" name="Test Location Tag" description="test desc" creator="1" date_created="2005-01-01 00:00:00.0" retired="false" uuid="001e503a-47ed-11df-bc8b-001e378eb67e"/>
+
+    <location_tag_map location_id="1" location_tag_id="1"/>
+    <location_tag_map location_id="3" location_tag_id="1"/>
+</dataset>


### PR DESCRIPTION
## Description of what I changed
I've added `LocationSearchAdviserTest` with tests for every method of `LocationService` affected by `LocationSearchAdviser` - it's also a good base for writing additional tests, with some generic methods included. It also includes a test dataset for this test suite.

**Note: This PR also introduces changes to `AOPContextSensitiveTest` and `TestWithAOP` classes, which resolve issue described in [LBAC-26](https://issues.openmrs.org/browse/LBAC-26). I ran the new code also on other existing tests (just to see if it is working correctly) and it runs just as expected.**

**All new and existing tests passed.** 
## Issue I worked on

https://issues.openmrs.org/browse/LBAC-23
GCI task instance: https://codein.withgoogle.com/dashboard/task-instances/6038365762748416/