### PR TITLE
Added exception for getPersonAttributeTypeByUuid in PersonServiceInterceptorAdvice

### DIFF
--- a/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/interceptor/PersonServiceInterceptorAdvice.java
+++ b/api/src/main/java/org/openmrs/module/locationbasedaccess/aop/interceptor/PersonServiceInterceptorAdvice.java
@@ -41,7 +41,7 @@ public class PersonServiceInterceptorAdvice  implements MethodInterceptor {
         }
         String accessibleLocationUuid = LocationUtils.getUserAccessibleLocationUuid(authenticatedUser);
         String locationAttributeUuid = Context.getAdministrationService().getGlobalProperty(LocationBasedAccessConstants.LOCATION_ATTRIBUTE_GLOBAL_PROPERTY_NAME);
-        if (StringUtils.isNotBlank(locationAttributeUuid)) {
+        if (StringUtils.isNotBlank(locationAttributeUuid) && (invocation.getMethod().getName() != "getPersonAttributeTypeByUuid")) {
             final PersonAttributeType personAttributeType = Context.getPersonService().getPersonAttributeTypeByUuid(locationAttributeUuid);
             if (accessibleLocationUuid != null) {
                 if(object instanceof List) {


### PR DESCRIPTION
When users calling  getSimilarPeople or other added methods, it calls the PersonServiceInterceptorAdvice. Inside the PersonServiceInterceptorAdvice, it calls getPersonAttributeTypeByUuid to get personAttributeType. Unfortunately, it makes calls like a loop and causes stackoverflowerror. 

So an exception for getPersonAttributeTypeByUuid() method  added in the PersonServiceInterceptorAdvice

Issue : https://issues.openmrs.org/browse/LBAC-27

