### PR TITLE
LBAC-26: Added support for testing MethodInterceptors having other ctors than 0-arg

### DIFF
--- a/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/AOPContextSensitiveTest.java
+++ b/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/AOPContextSensitiveTest.java
@@ -14,11 +14,16 @@ import org.openmrs.test.BaseModuleContextSensitiveTest;
 public abstract class AOPContextSensitiveTest extends BaseModuleContextSensitiveTest implements TestWithAOP {
 
     private Class<?> interceptorClass;
+    private MethodInterceptor interceptor;
 
     private Map<Class<?>, Advice> servicesMap = new HashMap<Class<?>, Advice>();
 
     public void setInterceptor(Class<? extends MethodInterceptor> interceptorClass) {
         this.interceptorClass = interceptorClass;
+    }
+
+    public void setInterceptor(MethodInterceptor interceptor) {
+        this.interceptor = interceptor;
     }
 
     public void addService(Class<? extends OpenmrsService> serviceClass) {
@@ -33,8 +38,18 @@ public abstract class AOPContextSensitiveTest extends BaseModuleContextSensitive
         setInterceptorAndServices(this);
 
         for (Class<?> serviceClass : servicesMap.keySet()) {
-            Advice advice = (Advice) (new AdvicePoint(serviceClass.getCanonicalName(), Context.loadClass(interceptorClass
-                    .getCanonicalName()))).getClassInstance();
+            Advice advice;
+            if (interceptorClass != null) {
+                advice = (Advice) (new AdvicePoint(serviceClass.getCanonicalName(), Context.loadClass(interceptorClass
+                        .getCanonicalName()))).getClassInstance();
+            }
+            else if (interceptor != null) {
+                advice = interceptor;
+            }
+            else {
+                throw new IllegalStateException("You must either set interceptor or interceptor class to setup the Context");
+            }
+
             servicesMap.put(serviceClass, advice);
             Context.addAdvice(Context.loadClass(serviceClass.getCanonicalName()), advice);
         }

--- a/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/TestWithAOP.java
+++ b/api/src/test/java/org/openmrs/module/locationbasedaccess/aop/common/TestWithAOP.java
@@ -13,6 +13,13 @@ public interface TestWithAOP {
     void setInterceptor(Class<? extends MethodInterceptor> interceptorClass);
 
     /**
+     * Sets an AOP method interceptor to be active on the test case.
+     *
+     * @param interceptor Eg. "MyInterceptor"
+     */
+    void setInterceptor(MethodInterceptor interceptor);
+
+    /**
      * Hooks the OpenMRS Services
      *
      * @param serviceClass


### PR DESCRIPTION
## Description of what I changed
I've modified `AOPContextSensitiveTest` and `TestWithAOP` to allow to use `MethodInterceptor`s instantiated by the user (to support the use of interceptors not having 0-arg ctr).

### Some context
Currently to use an interceptor in the test suite the only way to use it is by passing the class of the interceptor using `setInterceptor(Class<? extends MethodInterceptor>)` method. This class is later instantiated with `getClassInstance()` method which creates a new object like `new` keyword was used with 0-arg constructor.

Changes introduced with this PR will allow the developer to pass an explicitly constructed interceptor to the context, so the use of different constructors will be allowed. While most of the interceptors have 0-arg ctors by default, `LocationServiceInterceptorAdvice` must be instantiated with a `Set` of restricted method names as its argument - it is not possible to test this interceptor without changes I propose (firstly, because of lack of the 0-arg ctr, and secondly, because that interceptor would be useless anyways with no method filter defined).

**All tests passed.** 
## Issue I worked on

https://issues.openmrs.org/browse/LBAC-26